### PR TITLE
Small changes to the deposit tx primitive

### DIFF
--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -43,7 +43,7 @@ impl TxDeposit {
         len += self.source_hash.length();
         len += self.from.length();
         len += self.to.length();
-        len += self.mint.map(|mint| mint.length()).unwrap_or(1);
+        len += self.mint.map_or(1, |mint| mint.length());
         len += self.value.length();
         len += self.input.0.length();
         len += self.gas_limit.length();


### PR DESCRIPTION
# Overview

Small changes to the deposit transaction primitive:
* Deposit transactions don't have nonces; This value always defaults to `0`.
* Add getters for `source_hash`, `mint`, & `is_system_transaction` that may be enabled by the `optimism` feature flag.
* Temporarily panic when encoding a deposit transaction with a non-zero signature. We should handle this higher up, panicking here isn't the right move.