### PR TITLE
feat(node): Expose WAL Block Warning Threshold on EngineNodeLauncher

### DIFF
--- a/crates/node/builder/src/builder/add_ons.rs
+++ b/crates/node/builder/src/builder/add_ons.rs
@@ -4,6 +4,32 @@ use reth_node_api::{FullNodeComponents, NodeAddOns};
 
 use crate::{exex::BoxedLaunchExEx, hooks::NodeHooks};
 
+/// Configuration for node add-ons.
+///
+/// This struct holds additional configuration options that can be extended
+/// with new settings without breaking the `AddOns` struct.
+#[derive(Debug, Clone, Default)]
+pub struct AddOnsConfig {
+    /// The threshold for the number of blocks in the WAL before emitting a warning.
+    ///
+    /// For L2 chains with faster block times, this value should be increased proportionally
+    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
+    /// a value 6x higher than the default (768 instead of 128).
+    pub wal_blocks_warning: Option<usize>,
+}
+
+impl AddOnsConfig {
+    /// Sets the threshold for the number of blocks in the WAL before emitting a warning.
+    ///
+    /// For L2 chains with faster block times, this value should be increased proportionally
+    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
+    /// a value 6x higher than the default (768 instead of 128).
+    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
+        self.wal_blocks_warning = Some(threshold);
+        self
+    }
+}
+
 /// Additional node extensions.
 ///
 /// At this point we consider all necessary components defined.
@@ -14,22 +40,6 @@ pub struct AddOns<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub exexs: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
     /// Additional captured addons.
     pub add_ons: AddOns,
-    /// The threshold for the number of blocks in the WAL before emitting a warning.
-    ///
-    /// For L2 chains with faster block times, this value should be increased proportionally
-    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
-    /// a value 6x higher than the default (768 instead of 128).
-    pub wal_blocks_warning: Option<usize>,
-}
-
-impl<Node: FullNodeComponents, AO: NodeAddOns<Node>> AddOns<Node, AO> {
-    /// Sets the threshold for the number of blocks in the WAL before emitting a warning.
-    ///
-    /// For L2 chains with faster block times, this value should be increased proportionally
-    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
-    /// a value 6x higher than the default (768 instead of 128).
-    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
-        self.wal_blocks_warning = Some(threshold);
-        self
-    }
+    /// Additional configuration for add-ons.
+    pub config: AddOnsConfig,
 }

--- a/crates/node/builder/src/builder/add_ons.rs
+++ b/crates/node/builder/src/builder/add_ons.rs
@@ -14,4 +14,22 @@ pub struct AddOns<Node: FullNodeComponents, AddOns: NodeAddOns<Node>> {
     pub exexs: Vec<(String, Box<dyn BoxedLaunchExEx<Node>>)>,
     /// Additional captured addons.
     pub add_ons: AddOns,
+    /// The threshold for the number of blocks in the WAL before emitting a warning.
+    ///
+    /// For L2 chains with faster block times, this value should be increased proportionally
+    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
+    /// a value 6x higher than the default (768 instead of 128).
+    pub wal_blocks_warning: Option<usize>,
+}
+
+impl<Node: FullNodeComponents, AO: NodeAddOns<Node>> AddOns<Node, AO> {
+    /// Sets the threshold for the number of blocks in the WAL before emitting a warning.
+    ///
+    /// For L2 chains with faster block times, this value should be increased proportionally
+    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
+    /// a value 6x higher than the default (768 instead of 128).
+    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
+        self.wal_blocks_warning = Some(threshold);
+        self
+    }
 }

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -578,7 +578,7 @@ where
     /// builder.with_wal_blocks_warning(768)  // For 2-second block times (6x Ethereum mainnet)
     /// ```
     pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
-        self.builder.add_ons.wal_blocks_warning = Some(threshold);
+        self.builder.add_ons.config.wal_blocks_warning = Some(threshold);
         self
     }
 

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -566,6 +566,22 @@ where
         Self { builder: self.builder.map_add_ons(f), task_executor: self.task_executor }
     }
 
+    /// Sets the threshold for the number of blocks in the WAL before emitting a warning.
+    ///
+    /// For L2 chains with faster block times, this value should be increased proportionally
+    /// to avoid excessive warnings. For example, a chain with 2-second block times might use
+    /// a value 6x higher than the default (768 instead of 128).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// builder.with_wal_blocks_warning(768)  // For 2-second block times (6x Ethereum mainnet)
+    /// ```
+    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
+        self.builder.add_ons.wal_blocks_warning = Some(threshold);
+        self
+    }
+
     /// Sets the hook that is run once the rpc server is started.
     pub fn on_rpc_started<F>(self, hook: F) -> Self
     where

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -51,7 +51,7 @@ impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
                 hooks: NodeHooks::default(),
                 exexs: Vec::new(),
                 add_ons: (),
-                wal_blocks_warning: None,
+                config: Default::default(),
             },
         }
     }
@@ -182,7 +182,7 @@ where
                 hooks: NodeHooks::default(),
                 exexs: Vec::new(),
                 add_ons,
-                wal_blocks_warning: None,
+                config: Default::default(),
             },
         }
     }

--- a/crates/node/builder/src/builder/states.rs
+++ b/crates/node/builder/src/builder/states.rs
@@ -47,7 +47,12 @@ impl<T: FullNodeTypes> NodeBuilderWithTypes<T> {
             config,
             adapter,
             components_builder,
-            add_ons: AddOns { hooks: NodeHooks::default(), exexs: Vec::new(), add_ons: () },
+            add_ons: AddOns {
+                hooks: NodeHooks::default(),
+                exexs: Vec::new(),
+                add_ons: (),
+                wal_blocks_warning: None,
+            },
         }
     }
 }
@@ -173,7 +178,12 @@ where
             config,
             adapter,
             components_builder,
-            add_ons: AddOns { hooks: NodeHooks::default(), exexs: Vec::new(), add_ons },
+            add_ons: AddOns {
+                hooks: NodeHooks::default(),
+                exexs: Vec::new(),
+                add_ons,
+                wal_blocks_warning: None,
+            },
         }
     }
 }

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -82,7 +82,7 @@ impl EngineNodeLauncher {
         let NodeBuilderWithComponents {
             adapter: NodeTypesAdapter { database },
             components_builder,
-            add_ons: AddOns { hooks, exexs: installed_exex, add_ons, wal_blocks_warning },
+            add_ons: AddOns { hooks, exexs: installed_exex, add_ons, config: add_ons_config },
             config,
         } = target;
         let NodeHooks { on_component_initialized, on_node_started, .. } = hooks;
@@ -125,11 +125,11 @@ impl EngineNodeLauncher {
             .with_components(components_builder, on_component_initialized).await?;
 
         // spawn exexs if any
-        let mut exex_launcher = ctx.exex_launcher(installed_exex);
-        if let Some(threshold) = wal_blocks_warning {
-            exex_launcher = exex_launcher.with_wal_blocks_warning(threshold);
-        }
-        let maybe_exex_manager_handle = exex_launcher.launch().await?;
+        let maybe_exex_manager_handle = ctx
+            .exex_launcher(installed_exex)
+            .with_wal_blocks_warning(add_ons_config.wal_blocks_warning)
+            .launch()
+            .await?;
 
         // create pipeline
         let network_handle = ctx.components().network().clone();

--- a/crates/node/builder/src/launch/exex.rs
+++ b/crates/node/builder/src/launch/exex.rs
@@ -48,8 +48,12 @@ impl<Node: FullNodeComponents + Clone> ExExLauncher<Node> {
     /// For L2 chains with faster block times, this value should be increased proportionally
     /// to avoid excessive warnings. For example, a chain with 2-second block times might use
     /// a value 6x higher than the default (768 instead of 128).
-    pub const fn with_wal_blocks_warning(mut self, threshold: usize) -> Self {
-        self.wal_blocks_warning = threshold;
+    ///
+    /// If `None` is provided, the default threshold is used.
+    pub fn with_wal_blocks_warning(mut self, threshold: Option<usize>) -> Self {
+        if let Some(threshold) = threshold {
+            self.wal_blocks_warning = threshold;
+        }
         self
     }
 

--- a/crates/node/builder/src/lib.rs
+++ b/crates/node/builder/src/lib.rs
@@ -27,7 +27,10 @@ pub mod components;
 pub use components::{NodeComponents, NodeComponentsBuilder};
 
 mod builder;
-pub use builder::{add_ons::AddOns, *};
+pub use builder::{
+    add_ons::{AddOns, AddOnsConfig},
+    *,
+};
 
 mod launch;
 pub use launch::{


### PR DESCRIPTION
## Summary

This PR extends [#20867](https://github.com/paradigmxyz/reth/pull/20867) by exposing the WAL block warning threshold configuration through the node builder, enabling programmatic configuration for custom node implementations.

### Problem

While #20867 added the ability to configure the WAL warning threshold on `ExExLauncher`, nodes that use the standard builder pattern cannot currently pass this configuration through. The `EngineNodeLauncher` internally calls `ctx.launch_exex()` which uses the default threshold.

For L2 chains with faster block times (e.g., Base with ~2 second blocks vs Ethereum's ~12 seconds), the default threshold of 128 blocks triggers warnings too frequently, creating noise in logs.

### Solution

Add a `wal_blocks_warning` field to the `AddOns` struct and a corresponding builder method on `WithLaunchContext<NodeBuilderWithComponents>`. The `EngineNodeLauncher` reads this value from `AddOns` during launch and applies it to the underlying `ExExLauncher`.

### Usage

```rust
let builder = builder
    .with_types_and_provider::<MyNode, BlockchainProvider<_>>()
    .with_components(node.components())
    .with_add_ons(node.add_ons())
    .with_wal_blocks_warning(768)  // 6x default for ~6x faster block times
    .on_component_initialized(|_ctx| Ok(()));
```

###  Changes

- Added wal_blocks_warning: Option<usize> field to AddOns struct
- Added with_wal_blocks_warning(threshold: usize) method to AddOns
- Added with_wal_blocks_warning(threshold: usize) builder method to WithLaunchContext<NodeBuilderWithComponents>
- Updated EngineNodeLauncher::launch_node() to read the threshold from AddOns and apply it to exex_launcher() before launching
- Added documentation explaining the use case for L2 chains